### PR TITLE
fix: 하위 라우트에서 새로고침했을 시 페이지를 찾을 수 없는 문제 해결

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-import { BrowserRouter, Route, Routes } from 'react-router-dom';
+import { HashRouter, Route, Routes } from 'react-router-dom';
 import styled from 'styled-components';
 import Sidebar from './components/Sidebar';
 import HomePage from './pages/HomePage';
@@ -25,20 +25,20 @@ function App() {
   if (isLoading) return <main>Loading...</main>;
 
   return (
-    <BrowserRouter basename='/index.html'>
+    <HashRouter>
       <FullScreenFlexContainer>
         <Sidebar courses={courses.data} />
         <Container>
           <Routes>
             <Route path='/' element={<HomePage />} />
-            <Route path='course' element={<CoursePage />}>
+            <Route path='/course' element={<CoursePage />}>
               <Route path=':courseId' element={<CoursePage />} />
             </Route>
             <Route path='*' element={<NotFoundPage />} />
           </Routes>
         </Container>
       </FullScreenFlexContainer>
-    </BrowserRouter>
+    </HashRouter>
   );
 }
 


### PR DESCRIPTION
Client-side navigate로 인해 하위 라우트에 대한 html파일이 존재하지 않기 때문에 새로고침 시 페이지를 찾을 수 없는 이슈가 있었는데, `react-router-dom` 라이브러리의 `BrowserRouter`를 `HashRouter` 로 교체하여 해결

원래는 서버 단에서 모든 라우트에 대해 index.html 을 내려주도록 하는 것이 정석이지만 크롬 익스텐션에서 그게 안되기 때문에 해쉬로 해결